### PR TITLE
Only use Gauge spec to add transactions

### DIFF
--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -14,18 +14,4 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet  author="johnboyes"  id="2">  
-    <insert tableName="transactions">  
-        <column name="amount"  value="143.89"/>
-        <column name="time" value="${now}"/>  
-    </insert>
-    <insert tableName="transactions">  
-        <column name="amount"  value="19.27"/>
-        <column name="time" value="${now}"/>  
-    </insert>  
-    <insert tableName="transactions">  
-        <column name="amount"  value="50.00"/>
-        <column name="time" value="${now}"/>  
-    </insert>  
-</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this commit we were using Liquibase to seed the database with three initial transactions. Now that we also have the Gauge spec to add transactions into the database on demand, it is cleaner to just use the Gauge spec as the only way in which we add transactions.