### PR TITLE
Fix sql amount type

### DIFF
--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -6,7 +6,7 @@
             <column autoIncrement="true" name="id" type="INTEGER">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="transactions_pkey"/>
             </column>
-            <column name="amount" type="MONEY">
+            <column name="amount" type="DECIMAL(12, 2)">
                 <constraints nullable="false"/>
             </column>
             <column name="time" type="TIMESTAMP WITHOUT TIME ZONE">


### PR DESCRIPTION
Prior to this commit the sql type was incorrectly set as a numeric without indicating a scale.  This caused the Kafka connector to fail. The fix was to set the scale to 2.