### PR TITLE
Allow contributors to add data to their cloud DBs

### DIFF
--- a/.github/workflows/add_transactions.yml
+++ b/.github/workflows/add_transactions.yml
@@ -2,6 +2,10 @@ name: Add transactions
 run-name: Add transactions (triggered by @${{ github.actor }})
 on:
   workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
     secrets:
       database-host:
           required: true
@@ -18,6 +22,7 @@ jobs:
   liquibase-action:
     runs-on: ubuntu-latest
     name: Add transactions
+    environment: ${{ inputs.environment }}
     env:
       DATABASE_HOST: ${{ secrets.database-host }}
       DATABASE_NAME: ${{ secrets.database-name }}

--- a/.github/workflows/aws_add_transactions.yml
+++ b/.github/workflows/aws_add_transactions.yml
@@ -1,10 +1,18 @@
 name: Add transactions on AWS
 run-name: Add transactions on AWS (triggered by @${{ github.actor }})
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      github-username:
+        description: 'Your GitHub username (for secrets from corresponding GitHub environment)'
+        required: true 
+        type: string
 
 jobs:
   add-aws-transactions:
     uses: ./.github/workflows/add_transactions.yml
+    with:
+      environment: ${{ inputs.github-username }}
     secrets:
       database-host: ${{ secrets.AWS_DATABASE_HOST }}
       database-name: ${{ secrets.AWS_DATABASE_NAME }}

--- a/.github/workflows/elephantsql_add_transactions.yml
+++ b/.github/workflows/elephantsql_add_transactions.yml
@@ -1,10 +1,19 @@
 name: Add transactions on ElephantSQL
 run-name: Add transactions on ElephantSQL (triggered by @${{ github.actor }})
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      github-username:
+        description: 'Your GitHub username (for secrets from corresponding GitHub environment)'
+        required: true 
+        type: string
+
 
 jobs:
   add-aws-transactions:
     uses: ./.github/workflows/add_transactions.yml
+    with:
+      environment: ${{ inputs.github-username }}
     secrets:
       database-host: ${{ secrets.ELEPHANTSQL_DATABASE_HOST }}
       database-name: ${{ secrets.ELEPHANTSQL_DATABASE_NAME }}


### PR DESCRIPTION
Each contributor can now push data to their own cloud database instances when they run the GitHub Action CI/CD workflows, rather then everyone pushing data to the same database (which would be congested and error-prone).  This also allows contributors to use their own Kafka instance on [Confluent Cloud][1], giving each contributor a fully independent pipeline to experiment with.

Before running these [GitHub Action manual workflows][2] to push data into their own [AWS][3] or [ElephantSQL][4] cloud databases for the first time, each contributor must first create a
[GitHub Actions environment][5] with the name being their GitHub username and then add [GitHub Action environment secrets][6] with their AWS and/or ElephantSQL PostgreSQL connection details.

[1]: https://www.confluent.io/confluent-cloud/
[2]: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
[3]: https://aws.amazon.com/rds/postgresql
[4]: https://www.elephantsql.com
[5]: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
[6]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment