### PR TITLE
Add Python formatting CI checks using Black

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,3 +21,13 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
+
+  linter_name:
+    name: runner / black formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: reviewdog/action-black@v3
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check


### PR DESCRIPTION
[Black][1] is an opinionated Python code formatter (its name comes from the saying "any colour you like, as long as it's black").

We were already using Black in the devcontainer to automatically format our Python code.  This commit adds a Continuous Integration (CI) check on every push and every pull request that the Python code is formatted using Black.

As [this blog article about Golang's code formatter][2] (which is similar in intent to Black) explains, benefits of an opinionated code formatter include:

-  easier to write: never worry about minor formatting concerns while hacking away

-  easier to read: when all code looks the same you need not mentally convert others' formatting style into something you can understand

-  easier to maintain: mechanical changes to the source don't cause unrelated changes to the file's formatting; diffs show only the real changes.

-  uncontroversial: never have a debate about spacing or brace position ever again!

[1]: https://black.readthedocs.io
[2]: https://go.dev/blog/gofmt