### PR TITLE
Add Dockerfile CI hadolint linting via reviewdog

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,15 +33,14 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Install Liquibase
 ARG LIQUIBASE_VERSION=4.16.1
-ARG LIQUIBASE_DOWNLOAD_DIR=/tmp/liquibase
+ARG LIQUIBASE_DOWNLOAD_DIR=/tmp/liquibase/
 ARG LIQUIBASE_INSTALL_DIR=/usr/local/bin/liquibase/
 RUN export LIQUIBASE_BUNDLE=liquibase-${LIQUIBASE_VERSION}.zip \
     && mkdir -p ${LIQUIBASE_DOWNLOAD_DIR} \
     && mkdir -p ${LIQUIBASE_INSTALL_DIR} \
-    && cd ${LIQUIBASE_DOWNLOAD_DIR} || exit \
-    && wget -q --show-progress https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/${LIQUIBASE_BUNDLE} \
-    && unzip ${LIQUIBASE_BUNDLE} \
-    && cp -r ${LIQUIBASE_DOWNLOAD_DIR}/. ${LIQUIBASE_INSTALL_DIR} \
+    && wget -P ${LIQUIBASE_DOWNLOAD_DIR} -q --show-progress https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/${LIQUIBASE_BUNDLE} \
+    && unzip ${LIQUIBASE_DOWNLOAD_DIR}${LIQUIBASE_BUNDLE} -d ${LIQUIBASE_DOWNLOAD_DIR} \
+    && cp -r ${LIQUIBASE_DOWNLOAD_DIR}. ${LIQUIBASE_INSTALL_DIR} \
     && chmod +x ${LIQUIBASE_INSTALL_DIR}liquibase \
     && rm -rf ${LIQUIBASE_DOWNLOAD_DIR}
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,7 +46,8 @@ RUN export LIQUIBASE_BUNDLE=liquibase-${LIQUIBASE_VERSION}.zip \
 
 # Install Gauge
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+USER vscode
 RUN curl -SsL https://downloads.gauge.org/stable | sh \
-    && su vscode -c "gauge install python" \
-    && su vscode -c "gauge install html-report" \
-    && su vscode -c "gauge install screenshot"
+    && gauge install python \
+    && gauge install html-report \
+    && gauge install screenshot

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 # Use the PostgreSQL apt repository to install Postgres command line tools (see https://www.postgresql.org/download/linux/debian/)
 # Create the file repository configuration:
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
 # Import the repository signing key:
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,12 @@ RUN sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release 
 # [Optional] Uncomment this section to install additional OS packages.
 ARG POSTGRES_VERSION="14"
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends postgresql-client-${POSTGRES_VERSION}
+    && apt-get -y install --no-install-recommends postgresql-client-${POSTGRES_VERSION} \
+
+# Clean up apt-get as per https://github.com/hadolint/hadolint/wiki/DL3009
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Liquibase
 ARG LIQUIBASE_VERSION=4.16.1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,9 +17,9 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # Use the PostgreSQL apt repository to install Postgres command line tools (see https://www.postgresql.org/download/linux/debian/)
 # Create the file repository configuration:
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
 # Import the repository signing key:
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 # [Optional] Uncomment this section to install additional OS packages.
 ARG POSTGRES_VERSION="14"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -45,3 +45,15 @@ jobs:
           path: "."
           pattern: "*.sh"
           exclude: "./.git/*"
+
+  hadolint:
+    name: runner / hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: hadolint
+        uses: reviewdog/action-hadolint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -6,3 +6,10 @@ ignored:
   # for the devcontainer and not for anything production facing.
   # https://github.com/hadolint/hadolint/wiki/DL3008
   - DL3008
+
+  # Ignore Hadolint prompts to use just one of Wget and curl, as they both come preinstalled on our
+  # devcontainer.  Amending our bash commands to just use one of them isn't worth it, especially as
+  # the commands are generally the "standard" way to install the software in question from the
+  # command line.
+  # https://github.com/hadolint/hadolint/wiki/DL4001
+  - DL4001

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,0 +1,8 @@
+ignored:
+
+  # Updating pinned versions of apt-get software is cumbersome, as there is no automatic way to
+  # update them (Dependabot doesn't provide a way to do this, for instance).
+  # So we have decided to not pin apt-get versions in our devcontainer Dockerfile as they are just
+  # for the devcontainer and not for anything production facing.
+  # https://github.com/hadolint/hadolint/wiki/DL3008
+  - DL3008


### PR DESCRIPTION
NB we cannot do Dockerfile linting using Hadolint locally on the
devcontainer as there is an issue installing Hadolint there.  That's ok
though as we can catch any Dockerfile linting errors via the GitHub
Action CI check introduced in this commit, and then fix them on a
feature branch before merging to the `main` branch.

https://github.com/reviewdog/action-hadolint

https://github.com/hadolint/hadolint

* Fix Dockerfile linting errors