### PR TITLE
Improve further name of reusable workflow

### DIFF
--- a/.github/workflows/add_transactions.yml
+++ b/.github/workflows/add_transactions.yml
@@ -1,5 +1,5 @@
-name: Reusable workflow to add transactions
-run-name: Reusable workflow to add transactions (triggered by @${{ github.actor }})
+name: Reusable inner workflow to add transactions
+run-name: Reusable inner workflow to add transactions (triggered by @${{ github.actor }})
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Describing it as an "inner" workflow makes it more obvious it is not to be called directly.