### PR TITLE
Fix Gauge spec batching transactions bug

### DIFF
--- a/step_impl/step_impl.py
+++ b/step_impl/step_impl.py
@@ -79,8 +79,9 @@ def add_transactions(frequency, duration):
                     random_iban(),
                 ),
             )
+            conn.commit()
             time.sleep(int(frequency))
-        conn.commit()
+
         cur.close()
     except (Exception, Error) as err:
         error = err


### PR DESCRIPTION
The bank transactions added via the Gauge spec were all being added in one batch, rather than incrementally every x seconds.  The fix was to amend the Python indentation, so that each bank transaction is committed to the database individually.  Lesson learned is that [indentation in Python is very important][1].

[1]: https://teamtreehouse.com/community/how-does-python-know-where-the-end-of-a-forloop-code-block-is-theres-no-indication-of-when-execution-should-restart